### PR TITLE
silence warnings

### DIFF
--- a/face3d/media_coefficient_from_semantic_map_estimator.h
+++ b/face3d/media_coefficient_from_semantic_map_estimator.h
@@ -251,7 +251,7 @@ estimate_coefficients(std::vector<std::string> const& img_ids,
     for (int i=0; i<num_data; ++i) {
       int vert_idx = vertex_indices[i];
       const vpgl_affine_camera<double> aff_cam = local_affine(vgl_homg_point_3d<double>(mesh_vertices[i]));
-      const vnl_matrix<double> Pfull = aff_cam.get_matrix();
+      const vnl_matrix_fixed<double,3,4> Pfull = aff_cam.get_matrix();
       const vnl_matrix<double> Psub = Pfull.get_n_rows(0,2).get_n_columns(0,3);
       vnl_matrix<double> ai = Psub * subject_pca_components_transpose.get_n_rows(3*vert_idx,3);
       if ((ai.rows() != 2) || (ai.cols() != num_subject_components)) {

--- a/face3d/mesh_background_renderer_agnostic.h
+++ b/face3d/mesh_background_renderer_agnostic.h
@@ -313,7 +313,7 @@ render(CAM_T_OUT const& render_cam_params,
       // mirror the original image
       flip_image[i] = true;
       vnl_matrix_fixed<double,3,3> flip_x_3x3(0.0);
-      flip_x_3x3.set_diagonal(vnl_vector_fixed<double,3>(-1,1,1));
+      flip_x_3x3.set_diagonal(vnl_vector_fixed<double,3>(-1,1,1).as_ref());
       R_og *= flip_x_3x3;
     }
     vnl_vector_fixed<double,3> cam_z_vnl = R_og.get_row(2);


### PR DESCRIPTION
silence warnings regarding `vnl_{matrix,vector}_fixed` is being implicitly converted to a `vnl_{matrix,vector}`